### PR TITLE
Add highlight to reference links and ensure they're visible

### DIFF
--- a/src/ui/components/uic-ref--parent.ts
+++ b/src/ui/components/uic-ref--parent.ts
@@ -1,6 +1,7 @@
 import { Keymap, MarkdownView } from 'obsidian';
 import SNWPlugin from 'src/main';
 import { Instance, ReferenceElement } from 'tippy.js';
+import { scrollResultsIntoView } from 'src/utils';
 import { getUIC_Ref_Area } from "./uic-ref-area";
 import { setPluginVariableUIC_RefItem } from './uic-ref-item';
 
@@ -27,6 +28,7 @@ export const getUIC_Hoverview = async (instance: Instance)=>{
     setTimeout( async () => {
         await setFileLinkHandlers(false, popoverEl);
     }, 500);
+    scrollResultsIntoView(popoverEl);
 }
  
 
@@ -43,7 +45,7 @@ const getUIC_SidePane = async (refType: string, key: string, filePath: string, l
     sidepaneEL.addClass("snw-sidepane-container");   
     sidepaneEL.addClass("search-result-container");
     sidepaneEL.append( (await getUIC_Ref_Area(refType, key, filePath, lineNu, false)) )
- 
+
     setTimeout( async () => {
         await setFileLinkHandlers(false, sidepaneEL);
     }, 500);

--- a/src/ui/sidebar-pane.ts
+++ b/src/ui/sidebar-pane.ts
@@ -1,6 +1,7 @@
 // Sidepane used by SNW for displaying references
 
 import {ItemView, WorkspaceLeaf} from "obsidian";
+import { scrollResultsIntoView } from "src/utils";
 import {getReferencesCache} from "../indexer";
 import SNWPlugin from "../main";
 import { getUIC_SidePane } from "./components/uic-ref--parent";
@@ -46,6 +47,8 @@ export class SideBarPaneView extends ItemView {
         }
 
         this.containerEl.replaceChildren(await getUIC_SidePane(refType, key, filePath, lineNu))
+
+        scrollResultsIntoView(this.containerEl);
     }
 
     async onClose() { // Nothing to clean up.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,31 @@
+// pulled from here: https://github.com/slindberg/jquery-scrollparent/blob/master/jquery.scrollparent.js
+const getScrollParent = (element: HTMLElement, includeHidden: boolean): HTMLElement => {
+    let style = getComputedStyle(element);
+    const excludeStaticParent = style.position === "absolute";
+    const overflowRegex = includeHidden ? /(auto|scroll|hidden)/ : /(auto|scroll)/;
+
+    if (style.position === "fixed") return document.body;
+    for (let parent = element; (parent = parent.parentElement);) {
+        style = getComputedStyle(parent);
+        if (excludeStaticParent && style.position === "static") {
+            continue;
+        }
+        if (overflowRegex.test(style.overflow + style.overflowY + style.overflowX)) return parent;
+    }
+
+    return document.body;
+}
+
+const scrollResultsIntoView = (resultContainerEl: HTMLElement): void => {
+    const searchResults = resultContainerEl.querySelectorAll(".search-result-file-matched-text");
+    for (const searchResult of Array.from(searchResults)) {
+        if (searchResult instanceof HTMLElement) {
+            const scrollParent = getScrollParent(searchResult, true) as HTMLElement;
+            if (scrollParent) {
+                scrollParent.scrollTop = searchResult.offsetTop - scrollParent.offsetTop - (scrollParent.offsetHeight / 2)
+            }
+        }
+    }
+}
+
+export { getScrollParent, scrollResultsIntoView}


### PR DESCRIPTION
Reference links are now highlighted. If the reference section is too large for the container, it will be scrolled into view.

Resolves #50 

<img width="761" alt="image" src="https://user-images.githubusercontent.com/5632228/222226886-2aaa52a4-6355-486f-a007-81d72e518835.png">
