### PR TITLE
feat: respect global obsidian exluded files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,19 +10,19 @@
   "author": "TfTHacker",
   "license": "MIT",
   "devDependencies": {
-    "@codemirror/commands": "^6.1.2",
+    "@codemirror/commands": "^6.1.4",
     "@codemirror/language": "^6.3.2",
-    "@codemirror/search": "^6.2.3",
+    "@codemirror/search": "^6.4.0",
     "@codemirror/state": "^6.1.4",
-    "@codemirror/view": "^6.7.1",
-    "@types/node": "^18.11.15",
-    "@typescript-eslint/eslint-plugin": "^5.46.1",
-    "@typescript-eslint/parser": "^5.46.1",
+    "@codemirror/view": "^6.11.1",
+    "@types/node": "^20.1.3",
+    "@typescript-eslint/eslint-plugin": "^5.59.5",
+    "@typescript-eslint/parser": "^5.59.5",
     "builtin-modules": "^3.2.0",
     "esbuild": "0.16.7",
-    "obsidian": "^0.16.3",
-    "tslib": "2.4.1",
-    "typescript": "4.9.4"
+    "obsidian": "^1.2.8",
+    "tslib": "2.5.0",
+    "typescript": "5.0.4"
   },
   "dependencies": {
     "tippy.js": "^6.3.7"

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -36,7 +36,13 @@ export function buildLinksAndReferences(): void {
         if(resolvedFilePath?.path) {
             const resolvedTFile = thePlugin.app.metadataCache.getFirstLinkpathDest(resolvedFilePath.path, "/");
             const ghlink = !resolvedTFile ? resolvedFilePath.path : ""; // file doesnt exist, its a ghost link
-            
+            const sourceFile = thePlugin.app.metadataCache.getFirstLinkpathDest(src, "/");
+
+            if (thePlugin.settings.enableIngoredFiles) {
+                if (thePlugin.app.metadataCache.isUserIgnored(sourceFile?.path)) {
+                    return;
+                }
+            }
             allLinkResolutions.push(
                 {
                     reference: {
@@ -46,7 +52,7 @@ export function buildLinksAndReferences(): void {
                     },
                     resolvedFile: resolvedTFile, 
                     ghostLink: ghlink,
-                    sourceFile:   thePlugin.app.metadataCache.getFirstLinkpathDest(src, "/"),
+                    sourceFile:   sourceFile,
                     excludedFile: false
                 }
             )

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ declare module "obsidian" {
             }
         }
         iterateReferences:( cb: (sourcePath: string, reference: ReferenceCache)  => void ) => void
+        isUserIgnored(path: string): boolean;
     }
 
     interface Vault {

--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -20,6 +20,7 @@ export interface Settings {
 	enableRenderingLinksInLivePreview:		boolean;
 	enableRenderingHeadersInLivePreview:	boolean;
 	enableRenderingEmbedsInLivePreview:		boolean;
+	enableIngoredFiles:						boolean;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -40,7 +41,8 @@ export const DEFAULT_SETTINGS: Settings = {
 	enableRenderingBlockIdInLivePreview:	true,
 	enableRenderingLinksInLivePreview: 		true,
 	enableRenderingHeadersInLivePreview:	true,
-	enableRenderingEmbedsInLivePreview: 	true
+	enableRenderingEmbedsInLivePreview: 	true,
+	enableIngoredFiles:						false,
 }
 
 export class SettingsTab extends PluginSettingTab {
@@ -291,5 +293,18 @@ export class SettingsTab extends PluginSettingTab {
 				})
 				.setDynamicTooltip()
 			)
+
+		containerEl.createEl("h2", { text: "Index" });
+
+		new Setting(containerEl)
+			.setName("Enable Obsidian ingored files")
+			.setDesc("If enabled, will respect the general obsidian ignored files settings")
+			.addToggle((cb: ToggleComponent) => {
+				cb.setValue(this.thePlugin.settings.enableIngoredFiles);
+				cb.onChange(async (value: boolean) => {
+					this.thePlugin.settings.enableIngoredFiles = value;
+					await this.thePlugin.saveSettings();
+				});
+			});
 	}
 }


### PR DESCRIPTION
This will make strange new worlds respect obsidians global excluded files

<img width="799" alt="Screen Shot 2023-03-24 at 21 00 58" src="https://user-images.githubusercontent.com/1021965/227617192-362b3bbe-f506-43cd-8ed3-964915ae1a36.png">
<img width="796" alt="Screen Shot 2023-03-24 at 21 00 44" src="https://user-images.githubusercontent.com/1021965/227617197-800bd2c6-5ac8-4ad7-bd55-c1d13f74ce7d.png">


Mitigates Issues:
- https://github.com/TfTHacker/obsidian42-strange-new-worlds/issues/36
- https://github.com/TfTHacker/obsidian42-strange-new-worlds/issues/33
- https://github.com/TfTHacker/obsidian42-strange-new-worlds/issues/41

