### PR TITLE
Add context around links

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -222,3 +222,18 @@ body {
 .cm-gutters {
     z-index: 0 !important;
 }
+
+.snw-breadcrumbs {
+    display: flex;
+    align-items: baseline;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.snw-breadcrumbs > span {
+    margin-right: 1ch;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    font-weight: bold;
+    padding-left: 3px;
+    padding-right: 3px;
+}

--- a/src/ui/components/context/context-builder.ts
+++ b/src/ui/components/context/context-builder.ts
@@ -1,0 +1,163 @@
+import {
+    CachedMetadata,
+    HeadingCache,
+    ListItemCache,
+    Pos,
+    SectionCache,
+} from "obsidian";
+import { doesPositionIncludeAnother } from "./position-utils";
+
+export class ContextBuilder {
+    private readonly listItems: ListItemCache[];
+    private readonly headings: HeadingCache[];
+    private readonly sections: SectionCache[];
+
+    constructor(
+        private readonly fileContents: string,
+        { listItems = [], headings = [], sections = [] }: CachedMetadata
+    ) {
+        this.listItems = listItems;
+        this.headings = headings;
+        this.sections = sections;
+    }
+
+    getListItemIndexContaining = (searchedForPosition: Pos) => {
+        return this.listItems.findIndex(({ position }) =>
+            doesPositionIncludeAnother(position, searchedForPosition)
+        );
+    };
+
+    getSectionContaining = (searchedForPosition: Pos) => {
+        return this.sections.find(({ position }) =>
+            doesPositionIncludeAnother(position, searchedForPosition)
+        );
+    };
+
+    getListItemWithDescendants = (listItemIndex: number) => {
+        const rootListItem = this.listItems[listItemIndex];
+        const listItemWithDescendants = [rootListItem];
+
+        for (let i = listItemIndex + 1; i < this.listItems.length; i++) {
+            const nextItem = this.listItems[i];
+            if (nextItem.parent < rootListItem.position.start.line) {
+                return listItemWithDescendants;
+            }
+            listItemWithDescendants.push(nextItem);
+        }
+
+        return listItemWithDescendants;
+    };
+
+    getListBreadcrumbs(position: Pos) {
+        const listBreadcrumbs: ListItemCache[] = [];
+
+        if (this.listItems.length === 0) {
+            return listBreadcrumbs;
+        }
+
+        const thisItemIndex = this.getListItemIndexContaining(position);
+        const isPositionOutsideListItem = thisItemIndex < 0;
+
+        if (isPositionOutsideListItem) {
+            return listBreadcrumbs;
+        }
+
+        const thisItem = this.listItems[thisItemIndex];
+        let currentParent = thisItem.parent;
+
+        if (this.isTopLevelListItem(thisItem)) {
+            return listBreadcrumbs;
+        }
+
+        for (let i = thisItemIndex - 1; i >= 0; i--) {
+            const currentItem = this.listItems[i];
+
+            const currentItemIsHigherUp = currentItem.parent < currentParent;
+            if (currentItemIsHigherUp) {
+                listBreadcrumbs.unshift(currentItem);
+                currentParent = currentItem.parent;
+            }
+
+            if (this.isTopLevelListItem(currentItem)) {
+                return listBreadcrumbs;
+            }
+        }
+
+        return listBreadcrumbs;
+    }
+
+    getFirstSectionUnder(position: Pos) {
+        return this.sections.find(
+            (section) => section.position.start.line > position.start.line
+        );
+    }
+
+    getHeadingContaining(position: Pos) {
+        const index = this.getHeadingIndexContaining(position);
+        return this.headings[index];
+    }
+
+    getHeadingBreadcrumbs(position: Pos) {
+        const headingBreadcrumbs: HeadingCache[] = [];
+        if (this.headings.length === 0) {
+            return headingBreadcrumbs;
+        }
+
+        const collectAncestorHeadingsForHeadingAtIndex = (
+            startIndex: number
+        ) => {
+            let currentLevel = this.headings[startIndex].level;
+            const previousHeadingIndex = startIndex - 1;
+
+            for (let i = previousHeadingIndex; i >= 0; i--) {
+                const lookingAtHeading = this.headings[i];
+
+                if (lookingAtHeading.level < currentLevel) {
+                    currentLevel = lookingAtHeading.level;
+                    headingBreadcrumbs.unshift(lookingAtHeading);
+                }
+            }
+        };
+
+        const headingIndexAtPosition = this.getHeadingIndexContaining(position);
+        const positionIsInsideHeading = headingIndexAtPosition >= 0;
+
+        if (positionIsInsideHeading) {
+            collectAncestorHeadingsForHeadingAtIndex(headingIndexAtPosition);
+            return headingBreadcrumbs;
+        }
+
+        const headingIndexAbovePosition = this.getIndexOfHeadingAbove(position);
+        const positionIsBelowHeading = headingIndexAbovePosition >= 0;
+
+        if (positionIsBelowHeading) {
+            const headingAbovePosition =
+                this.headings[headingIndexAbovePosition];
+            headingBreadcrumbs.unshift(headingAbovePosition);
+            collectAncestorHeadingsForHeadingAtIndex(headingIndexAbovePosition);
+            return headingBreadcrumbs;
+        }
+
+        return headingBreadcrumbs;
+    }
+
+    private isTopLevelListItem(listItem: ListItemCache) {
+        return listItem.parent <= 0;
+    }
+
+    private getIndexOfHeadingAbove(position: Pos) {
+        return this.headings.reduce(
+            (previousIndex, lookingAtHeading, index) =>
+                lookingAtHeading.position.start.line < position.start.line
+                    ? index
+                    : previousIndex,
+            -1
+        );
+    }
+
+    private getHeadingIndexContaining(position: Pos) {
+        return this.headings.findIndex(
+            (heading) => heading.position.start.line === position.start.line
+        );
+    }
+}

--- a/src/ui/components/context/formatting-utils.ts
+++ b/src/ui/components/context/formatting-utils.ts
@@ -1,0 +1,42 @@
+import { HeadingCache, ListItemCache } from "obsidian";
+import {
+    getTextAtPosition,
+    getTextFromLineStartToPositionEnd,
+} from "./position-utils";
+
+export const chainBreadcrumbs = (lines: string[]) =>
+    lines
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .join(" ➤ ");
+
+export const formatListBreadcrumbs = (
+    fileContents: string,
+    breadcrumbs: ListItemCache[]
+) =>
+    chainBreadcrumbs(
+        breadcrumbs
+            .map((listCache) =>
+                getTextAtPosition(fileContents, listCache.position)
+            )
+            .map((listText) => listText.trim().replace(/^-\s+/, ""))
+    );
+
+export const formatListWithDescendants = (
+    textInput: string,
+    listItems: ListItemCache[]
+) => {
+    const root = listItems[0];
+    const leadingSpacesCount = root.position.start.col;
+    return listItems
+        .map((itemCache) =>
+            getTextFromLineStartToPositionEnd(
+                textInput,
+                itemCache.position
+            ).slice(leadingSpacesCount)
+        )
+        .join("\n");
+};
+
+export const formatHeadingBreadCrumbs = (breadcrumbs: HeadingCache[]) =>
+    chainBreadcrumbs(breadcrumbs.map((headingCache) => headingCache.heading));

--- a/src/ui/components/context/position-utils.ts
+++ b/src/ui/components/context/position-utils.ts
@@ -1,0 +1,13 @@
+import { Pos } from "obsidian";
+
+export const getTextAtPosition = (textInput: string, pos: Pos) =>
+    textInput.substring(pos.start.offset, pos.end.offset);
+
+export const getTextFromLineStartToPositionEnd = (
+    textInput: string,
+    pos: Pos
+) => textInput.substring(pos.start.offset - pos.start.col, pos.end.offset);
+
+export const doesPositionIncludeAnother = (container: Pos, child: Pos) =>
+    container.start.offset <= child.start.offset &&
+    container.end.offset >= child.end.offset;


### PR DESCRIPTION
First of all, thank you for a great plugin! 

This change is inspired by how tools like Roamresearch and Logseq display context around links.

- If the item has headings above it, show the ancestor headings chained together
- If the link is in a bullet list, show its ancestors chained together as well as descendants
- If the link is in a heading, show the section right below it
- If the link is in a section, just show the complete section

Here is a demo:
![image](https://user-images.githubusercontent.com/41428836/229912189-8dac6238-5d0f-4bc3-bdc2-800a08f9e10f.png)


