### PR TITLE
Add modifier key (ctrl / cmd) to prevent hover previews from popping up too much

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,9 @@ export default class SNWPlugin extends Plugin {
             buildLinksAndReferences()
         }, 1000, true);
 
+        // TODO: probably still want to keep metadataCache.on("resolve") in case non-editor change triggers a file update
         this.registerEvent(this.app.metadataCache.on("resolve", indexDebounce ));
+        this.registerEvent(this.app.workspace.on("editor-change", indexDebounce ));
 
         this.app.workspace.registerHoverLinkSource(this.appID, {
             display: this.appName,

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ export default class SNWPlugin extends Plugin {
     lastSelectedReferenceFilePath : string;
     lastSelectedLineNumber: number;
     snwAPI: SnwAPI;
-    markdownPostProcessor: MarkdownPostProcessor = null;
+    markdownPostProcessor: MarkdownPostProcessor | null = null;
     editorExtensions: Extension[] = [];
     commands: PluginCommands;
 
@@ -135,7 +135,11 @@ export default class SNWPlugin extends Plugin {
         if(this.settings.displayInlineReferencesMarkdown && this.showCountsActive && this.markdownPostProcessor===null) {
             this.markdownPostProcessor = this.registerMarkdownPostProcessor((el, ctx) => markdownPreviewProcessor(el, ctx));
         } else {
-            MarkdownPreviewRenderer.unregisterPostProcessor(this.markdownPostProcessor);
+            if(!this.markdownPostProcessor) {
+                console.log("Markdown post processor is not registered");
+            } else {
+                MarkdownPreviewRenderer.unregisterPostProcessor(this.markdownPostProcessor);
+            }
             this.markdownPostProcessor=null;
         }
     }
@@ -203,7 +207,11 @@ export default class SNWPlugin extends Plugin {
     onunload(): void {
         console.log("unloading " + this.appName)
         try {
-            MarkdownPreviewRenderer.unregisterPostProcessor(this.markdownPostProcessor);
+            if(!this.markdownPostProcessor) {
+                console.log("Markdown post processor is not registered");
+            } else {
+                MarkdownPreviewRenderer.unregisterPostProcessor(this.markdownPostProcessor);
+            }
             this.app.workspace.unregisterHoverLinkSource(this.appID);
         } catch (error) { /* don't do anything */ }
     }

--- a/src/snwApi.ts
+++ b/src/snwApi.ts
@@ -38,7 +38,7 @@ export default class SnwAPI {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getMetaInfoByCurrentFile = async (): Promise<any> => {
-        return this.getMetaInfoByFileName(app.workspace.getActiveFile().path)
+        return this.getMetaInfoByFileName(app.workspace.getActiveFile()?.path || "")
     }
 
     /**
@@ -51,8 +51,8 @@ export default class SnwAPI {
         const currentFile = app.metadataCache.getFirstLinkpathDest(fileName, "/")
         return {
             TFile: currentFile,
-            metadataCache: app.metadataCache.getFileCache(currentFile),
-            SnwTransformedCache: getSNWCacheByFile(currentFile),
+            metadataCache: currentFile ? app.metadataCache.getFileCache(currentFile) : null,
+            SnwTransformedCache: currentFile ? getSNWCacheByFile(currentFile) : null,
         } 
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,11 +51,11 @@ export interface Link {
         displayText: string
         position: Pos
     }
-    resolvedFile: TFile
+    resolvedFile: TFile | null
     // resolvedPaths: string[]
     ghostLink: string
-    realLink: string  //the real link in the markdonw
-    sourceFile: TFile 
+    realLink: string  //the real link in the markdown
+    sourceFile: TFile | null
     excludedFile: boolean;
 }
 

--- a/src/ui/components/uic-ref--parent.ts
+++ b/src/ui/components/uic-ref--parent.ts
@@ -5,7 +5,7 @@ import { scrollResultsIntoView } from 'src/utils';
 import { getUIC_Ref_Area } from "./uic-ref-area";
 import { setPluginVariableUIC_RefItem } from './uic-ref-item';
 
-let thePlugin: SNWPlugin = null;
+let thePlugin: SNWPlugin;
 
 export function setPluginVariableForUIC(plugin: SNWPlugin) {
     thePlugin = plugin;

--- a/src/ui/headerRefCount.ts
+++ b/src/ui/headerRefCount.ts
@@ -108,15 +108,33 @@ function processHeader(mdView: MarkdownView) {
         }
     // }
 
+    // TODO: add a SNW setting toggle to enable/disable the modifier key instead of hardcoding it to true
+    const requireModifierKey = true as boolean;
+    // defaults to showing tippy on hover, but if requireModifierKey is true, then only show on ctrl/meta key
+    let showTippy = true;
     const tippyObject =  tippy(wrapper, {
         interactive: true,
         appendTo: () =>  document.body, 
         allowHTML: true,
         zIndex: 9999,
         placement: "auto-end",
-        onShow(instance) { setTimeout( async () => {
-            await getUIC_Hoverview(instance)
-        }, 1); } 
+        onTrigger(instance, event) {
+            const mouseEvent = event as MouseEvent;
+            if(requireModifierKey === false) return;
+            if(mouseEvent.ctrlKey || mouseEvent.metaKey) {
+                showTippy = true;
+            } else {
+                showTippy = false;
+            }
+        },
+        onShow(instance) {
+            // returning false will cancel the show (coming from onTrigger)
+            if(!showTippy) return false;
+
+            setTimeout( async () => {
+                await getUIC_Hoverview(instance)
+            }, 1);
+        } 
     });
 
     tippyObject.popper.classList.add("snw-tippy");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ const getScrollParent = (element: HTMLElement, includeHidden: boolean): HTMLElem
     const overflowRegex = includeHidden ? /(auto|scroll|hidden)/ : /(auto|scroll)/;
 
     if (style.position === "fixed") return document.body;
-    for (let parent = element; (parent = parent.parentElement);) {
+    for (let parent: HTMLElement | null = element; (parent = parent.parentElement);) {
         style = getComputedStyle(parent);
         if (excludeStaticParent && style.position === "static") {
             continue;

--- a/src/view-extensions/htmlDecorations.ts
+++ b/src/view-extensions/htmlDecorations.ts
@@ -11,7 +11,7 @@ export function setPluginVariableForHtmlDecorations(plugin: SNWPlugin) {
 }
 
 /**
- * Shared function between refrences-cm6.ts and references-preview.s
+ * Shared function between references-cm6.ts and references-preview.s
  * This decoration is just the html box drawn into the document with the count of references.
  * It is used in the header as well as inline in the document. If a user clicks on this element,
  * the function processHtmlDecorationReferenceEvent is called
@@ -21,7 +21,7 @@ export function setPluginVariableForHtmlDecorations(plugin: SNWPlugin) {
  * @param {string} referenceType    The type of references (block, embed, link, header)
  * @param {string} key              Unique key used to identify this reference based on its type
  * @param {string} filePath         File path in file in vault
- * @param {string} attachCSSClass   if special class is need for the elment
+ * @param {string} attachCSSClass   if special class is need for the element
  * @return {*}  {HTMLElement}
  */
 export function htmlDecorationForReferencesElement(count: number, referenceType: string, realLink: string, key: string, filePath: string, attachCSSClass: string, lineNu: number): HTMLElement {
@@ -65,11 +65,11 @@ export /**
  * @param {HTMLElement} target
  */
 const processHtmlDecorationReferenceEvent = async (target: HTMLElement) => {
-    const refType = target.getAttribute("data-snw-type");
-    const realLink = target.getAttribute("data-snw-realLink");
-    const key = target.getAttribute("data-snw-key");
-    const filePath = target.getAttribute("data-snw-filepath");
-    const lineNu = target.getAttribute("snw-data-line-number");
+    const refType = target.getAttribute("data-snw-type") ?? "";
+    const realLink = target.getAttribute("data-snw-realLink") ?? "";
+    const key = target.getAttribute("data-snw-key") ?? "";
+    const filePath = target.getAttribute("data-snw-filepath") ?? "";
+    const lineNu = target.getAttribute("snw-data-line-number") ?? "";
 
     if(thePlugin.snwAPI.enableDebugging?.HtmlDecorationElements) 
         thePlugin.snwAPI.console("htmlDecorations.processHtmlDecorationReferenceEvent: target, realLink, key, refType, filePath", target,realLink, key,refType, filePath);

--- a/src/view-extensions/htmlDecorations.ts
+++ b/src/view-extensions/htmlDecorations.ts
@@ -43,15 +43,34 @@ export function htmlDecorationForReferencesElement(count: number, referenceType:
     if(thePlugin?.snwAPI.enableDebugging?.HtmlDecorationElements) 
         thePlugin.snwAPI.console("returned element", element);
 
+    // TODO: add a SNW setting toggle to enable/disable the modifier key instead of hardcoding it to true
+    const requireModifierKey = true as boolean;
+    // defaults to showing tippy on hover, but if requireModifierKey is true, then only show on ctrl/meta key
+    let showTippy = true;
     const tippyObject =  tippy(element, {
         interactive: true,
         appendTo: () => document.body,
         allowHTML: true,
         zIndex: 9999,
         placement: "auto-end",
-        onShow(instance) { setTimeout( async () => {
-            await getUIC_Hoverview(instance)
-        }, 1); } 
+        // trigger: "click", // on click is another option instead of hovering at all
+        onTrigger(instance, event) {
+            const mouseEvent = event as MouseEvent;
+            if(requireModifierKey === false) return;
+            if(mouseEvent.ctrlKey || mouseEvent.metaKey) {
+                showTippy = true;
+            } else {
+                showTippy = false;
+            }
+        },
+        onShow(instance) {
+            // returning false will cancel the show (coming from onTrigger)
+            if(!showTippy) return false;
+
+            setTimeout( async () => {
+                await getUIC_Hoverview(instance)
+            }, 1);
+        } 
     });
     
     tippyObject.popper.classList.add("snw-tippy");


### PR DESCRIPTION
I put the piping in place for a Setting to be added with a Toggle to turn this on or off but figured @TfTHacker could do that much quicker than me ;) I left a TODO comment in where to update it. In this PR it is hardcoded as `true` requiring ctrl or cmd to  be held on hover for the popovers to show.

This includes the changes from both PR #117 as well as PR #118.