### PR TITLE
Handle deferred views

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^8.57.0",
     "@html-eslint/eslint-plugin": "^0.24.1",
     "@html-eslint/parser": "^0.24.1",
-    "@types/obsidian-typings": "github:Fevol/obsidian-typings#1.0.5",
+    "obsidian-typings": "^2.3.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@typescript-eslint/parser": "^7.12.0",
     "@typescript-eslint/utils": "^7.12.0",
@@ -48,7 +48,7 @@
     "remark-preset-prettier": "^2.0.1",
     "tslib": "^2.6.2",
     "typescript": "5.4.5",
-    "obsidian": "1.5.7"
+    "obsidian": "^1.7.2"
   },
   "dependencies": {
     "preact": "^10.22.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^8.57.0",
     "@html-eslint/eslint-plugin": "^0.24.1",
     "@html-eslint/parser": "^0.24.1",
-    "@types/obsidian-typings": "github:Fevol/obsidian-typings",
+    "@types/obsidian-typings": "github:Fevol/obsidian-typings#1.0.5",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@typescript-eslint/parser": "^7.12.0",
     "@typescript-eslint/utils": "^7.12.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface TransformedCachedItem {
   references: Link[];
   original?: string;
   headerMatch?: string; //used for matching headers
+  displayText?: string;
 }
 
 export interface TransformedCache {

--- a/src/ui/frontmatterRefCount.ts
+++ b/src/ui/frontmatterRefCount.ts
@@ -13,7 +13,7 @@ export function setPluginVariableForFrontmatterLinksRefCount(snwPlugin: SNWPlugi
 // Iterates all open documents to see if they are markdown file, and if so called processHeader
 function setFrontmatterLinksReferenceCounts() {
   plugin.app.workspace.iterateAllLeaves((leaf: WorkspaceLeaf) => {
-    if (leaf.view.getViewType() === 'markdown') processFrontmatterLinks(leaf.view as MarkdownView);
+    if (leaf.view instanceof MarkdownView) processFrontmatterLinks(leaf.view as MarkdownView);
   });
 }
 
@@ -37,7 +37,6 @@ function processFrontmatterLinks(mdView: MarkdownView) {
   // if no frontmatter links, exit
   if (transformedCache.frontmatterLinks?.length === 0) return;
 
-  // @ts-ignore - metadataEditor is undocumented type
   mdView.metadataEditor.rendered.forEach((item) => {
     const innerLink = item.valueEl.querySelector('.metadata-link-inner.internal-link');
     if (innerLink) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,9 @@
     "isolatedModules": true,
     "strictNullChecks": true,
     "lib": ["DOM", "ES5", "ES6", "ES7", "ES2021"],
+    "types": [
+      "obsidian-typings"
+    ],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "moduleDetection": "auto",


### PR DESCRIPTION
When an editor view is not yet rendered (Obsidian >= v1.7.2), `view.file` is `null`, causing a TypeError.

Check that view is rendered first before operating on it. see:

https://docs.obsidian.md/Plugins/Guides/Understanding+deferred+views

fixes #148 